### PR TITLE
AMQ role based access control support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
       <source.version>1.6</source.version>
       <target.version>1.6</target.version>
       <!-- for test dependencies -->
-      <artemis-version>2.0.0.amq-700013</artemis-version>
+      <artemis-version>2.6.0.amq-720001</artemis-version>
       <junit-version>4.12</junit-version>
       <rhq-core-version>4.12.0</rhq-core-version>
       <geronimo.jms.2.spec.version>1.0-alpha-2</geronimo.jms.2.spec.version>
@@ -136,6 +136,18 @@
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-server</artifactId>
          <type>test-jar</type>
+         <version>${artemis-version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-dto</artifactId>
+         <version>${artemis-version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-cli</artifactId>
          <version>${artemis-version}</version>
          <scope>test</scope>
       </dependency>

--- a/src/main/java/org/jbosson/plugins/amq/ArtemisServerComponent.java
+++ b/src/main/java/org/jbosson/plugins/amq/ArtemisServerComponent.java
@@ -43,7 +43,7 @@ import java.io.File;
  */
 public class ArtemisServerComponent<T extends ResourceComponent<?>> implements JMXComponent<T> {
 
-    private final Log log = LogFactory.getLog(getClass());
+    private static final Log log = LogFactory.getLog(ArtemisServerComponent.class);
 
     // needed to be copied from JMXServerComponent, since these are not protected, gaahhh!
     protected EmsConnection connection;
@@ -83,6 +83,8 @@ public class ArtemisServerComponent<T extends ResourceComponent<?>> implements J
         Configuration pluginConfig = context.getPluginConfiguration();
         String connectionTypeDescriptorClassName = pluginConfig.getSimple(JMXDiscoveryComponent.CONNECTION_TYPE)
             .getStringValue();
+        PluginUtil.loadPluginConfiguration(pluginConfig);
+
         if (JMXDiscoveryComponent.PARENT_TYPE.equals(connectionTypeDescriptorClassName)) {
             // Our parent is itself a JMX component, so just reuse its connection.
             this.connection = ((JMXComponent) context.getParentResourceComponent()).getEmsConnection();
@@ -97,7 +99,7 @@ public class ArtemisServerComponent<T extends ResourceComponent<?>> implements J
                 // avoid loading AttachNotSupportedException class, since its optional
                 if (e.getCause() != null &&
                     e.getCause().getClass().getName().equals(
-                        ArtemisServerDiscoveryComponent.ATTACH_NOT_SUPPORTED_EXCEPTION_CLASS_NAME)) {
+                        PluginUtil.ATTACH_NOT_SUPPORTED_EXCEPTION_CLASS_NAME)) {
 
                     // create a connection provider using JvmStatUtility
                     final Class<?> connectionTypeDescriptorClass;

--- a/src/main/java/org/jbosson/plugins/amq/PluginUtil.java
+++ b/src/main/java/org/jbosson/plugins/amq/PluginUtil.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.jbosson.plugins.amq;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.rhq.core.domain.configuration.Configuration;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.Set;
+
+public final class PluginUtil {
+
+   private static final Log log = LogFactory.getLog(PluginUtil.class);
+
+   public static final String SYSTEM_PROPERTIES_GROUP = "systemProperties";
+   public static final String VERSION_FILE_PROPERTY = "versionFile";
+   public static final String RESOURCE_KEY_PROPERTY = "resourceKey";
+   public static final String HOME_PROPERTY = "homeProperty";
+   public static final String LOG_FILE_PROPERTY = "logFile";
+   public static final String ATTACH_NOT_SUPPORTED_EXCEPTION_CLASS_NAME = "com.sun.tools.attach.AttachNotSupportedException";
+   public static final String CONFIG_FILE_NAME = "org.jboss.rh-messaging.amq.jon.cfg";
+
+   public static void loadPluginConfiguration(Configuration pluginConfig) {
+
+      final String homePropertyName = pluginConfig.getSimpleValue(HOME_PROPERTY);
+
+      String homeInstance = pluginConfig.getSimpleValue(homePropertyName);
+
+      if (homeInstance == null) {
+         homeInstance = System.getProperty(homePropertyName);
+      }
+
+      String configFileName = homeInstance + File.separator + "etc" + File.separator + CONFIG_FILE_NAME;
+
+      File cfgFile = new File(configFileName);
+      Properties properties = new Properties();
+
+      if (cfgFile.exists()) {
+         FileInputStream stream = null;
+         try {
+            stream = new FileInputStream(cfgFile);
+            properties.load(stream);
+         } catch (IOException e) {
+            log.warn("Failed to load properties", e);
+         } finally {
+            if (stream != null) {
+               try {
+                  stream.close();
+               } catch (IOException e) {
+                  // ignore
+               }
+            }
+         }
+      }
+      Set<String> propNames = properties.stringPropertyNames();
+      Iterator<String> iter = propNames.iterator();
+      while (iter.hasNext()) {
+         String key = iter.next();
+         pluginConfig.setSimpleValue(key, properties.getProperty(key));
+      }
+   }
+}

--- a/src/test/java/org/jbosson/plugins/amq/jmx/AmqBrokerOperationsTest.java
+++ b/src/test/java/org/jbosson/plugins/amq/jmx/AmqBrokerOperationsTest.java
@@ -25,16 +25,6 @@ import org.rhq.core.pluginapi.operation.OperationResult;
 
 public class AmqBrokerOperationsTest extends AmqJonRuntimeTestBase {
 
-   private ArtemisServiceComponent brokerComponent;
-   private EmsBean brokerBean;
-
-   @Before
-   public void setUp() throws Exception {
-      super.setUp();
-      brokerBean = getAmQServerBean();
-      brokerComponent = new ArtemisServiceComponent();
-   }
-
    @Test
    public void testInvokingListConnectionIDs() throws Exception {
       OperationInfo op = getBrokerOperation(ArtemisServiceComponent.LIST_CONNECTION_IDS_OPERATION);

--- a/src/test/java/org/jbosson/plugins/amq/jmx/JmxAuthTest.java
+++ b/src/test/java/org/jbosson/plugins/amq/jmx/JmxAuthTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.jbosson.plugins.amq.jmx;
+
+import org.apache.activemq.artemis.cli.factory.jmx.ManagementFactory;
+import org.apache.activemq.artemis.core.server.management.ManagementContext;
+import org.apache.activemq.artemis.dto.ManagementContextDTO;
+import org.jbosson.plugins.amq.ArtemisServiceComponent;
+import org.jbosson.plugins.amq.OperationInfo;
+import org.junit.Test;
+import org.mc4j.ems.connection.EmsConnectException;
+import org.mc4j.ems.connection.EmsConnection;
+import org.mc4j.ems.connection.settings.ConnectionSettings;
+import org.mc4j.ems.connection.support.ConnectionProvider;
+import org.mc4j.ems.connection.support.metadata.JSR160ConnectionTypeDescriptor;
+import org.rhq.core.domain.configuration.PropertyList;
+import org.rhq.core.pluginapi.operation.OperationResult;
+
+import java.net.URL;
+
+public class JmxAuthTest extends AmqJonRuntimeTestBase {
+
+   @Override
+   protected ManagementContext configureJmxAccess() throws Exception {
+      ManagementContextDTO managementDTO = getManagementDTO();
+      ManagementContext managementContext = ManagementFactory.create(managementDTO);
+      return managementContext;
+   }
+
+   private ManagementContextDTO getManagementDTO() throws Exception {
+      URL url = getClass().getClassLoader().getResource("management.xml");
+      String configuration = "xml:" + url.toURI().toString().substring("file:".length());
+
+      configuration = configuration.replace("\\", "/");
+
+      ManagementContextDTO mContextDTO = ManagementFactory.createJmxAclConfiguration(configuration, null, null, null);
+      return mContextDTO;
+   }
+
+   @Override
+   protected String getJmxCredentials() {
+      return "jmxpassword";
+   }
+
+   protected String getJmxPrincipal() {
+      return "jmxuser";
+   }
+
+   @Test
+   public void testJmxConnectionAuthen() {
+      //ok
+      connectJmxWithAuthen("jmxuser", "jmxpassword");
+      //wrong pass
+      try {
+         connectJmxWithAuthen("jmxuser", "wrongpassword");
+         fail("didn't get exception with wrong password");
+      } catch (SecurityException e) {
+         //correct
+      }
+      //non exist user
+      try {
+         connectJmxWithAuthen("nouser", "jmxpassword");
+         fail("didn't get exception with wrong principal");
+      } catch (SecurityException e) {
+         //correct
+      }
+   }
+
+   @Test
+   public void testInvokeUsingValidRole() throws Exception {
+      OperationInfo op = getBrokerOperation(ArtemisServiceComponent.LIST_CONNECTION_IDS_OPERATION);
+      OperationResult result = brokerComponent.invokeOperation(op.getName(), null, brokerBean);
+      PropertyList connList = result.getComplexResults().getList("result");
+      assertEquals(0, connList.getList().size());
+
+      //create one connection
+      createConnection();
+      result = brokerComponent.invokeOperation(op.getName(), null, brokerBean);
+      connList = result.getComplexResults().getList("result");
+      assertEquals(1, connList.getList().size());
+   }
+
+   private void connectJmxWithAuthen(String user, String password) {
+      ConnectionSettings emsConnectionSettings = new ConnectionSettings();
+      JSR160ConnectionTypeDescriptor descriptor = new JSR160ConnectionTypeDescriptor();
+      emsConnectionSettings.initializeConnectionType(descriptor);
+      emsConnectionSettings.setServerUrl(jmxServiceURL);
+      emsConnectionSettings.setPrincipal(user);
+      emsConnectionSettings.setCredentials(password);
+
+      ConnectionProvider provider = emsFactory.getConnectionProvider(emsConnectionSettings);
+      EmsConnection jmxConn = null;
+      try {
+         jmxConn = provider.connect();
+      } catch (EmsConnectException e) {
+         if (e.getCause() instanceof SecurityException) {
+            throw new SecurityException(e);
+         } else {
+            throw e;
+         }
+      } finally {
+         if (jmxConn != null) {
+            jmxConn.close();
+         }
+      }
+   }
+}

--- a/src/test/resources/artemis-roles.properties
+++ b/src/test/resources/artemis-roles.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+amq = guest,jmxuser

--- a/src/test/resources/artemis-users.properties
+++ b/src/test/resources/artemis-users.properties
@@ -1,0 +1,19 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+guest = ENC(1024:3A339D50F1D35BFC6DF60874E0196960720FC28466599C347BBBC706940BA2C9:D0F0C18DE07F2996827203B13C7777E723D49A3EC23F0FCD40DA9E418BF7EB3923649EEF60591560C0B6CE32D603E899247744F150BC47EF1EF29FE46079646A)
+jmxuser = ENC(1024:B369D03E053F97D8F9DCDB12FE5580D6773C19BCC1578DE37492F704E735CEC4:A08470DF7D550B769FFF67E9C381E0AAE397B308EC1DFF420E13EF68F156F54780997A3AE51BEB86FACFEE7FD2175719C9D9619D73908896475C2D2A22C9047C)

--- a/src/test/resources/login.config
+++ b/src/test/resources/login.config
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+activemq {
+   org.apache.activemq.artemis.spi.core.security.jaas.PropertiesLoginModule sufficient
+       debug=false
+       reload=true
+       org.apache.activemq.jaas.properties.user="artemis-users.properties"
+       org.apache.activemq.jaas.properties.role="artemis-roles.properties";
+};

--- a/src/test/resources/management.xml
+++ b/src/test/resources/management.xml
@@ -1,0 +1,48 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<management-context xmlns="http://activemq.org/schema">
+    <connector connector-port="11099"/>
+    <authorisation>
+        <whitelist>
+            <entry domain="hawtio"/>
+        </whitelist>
+        <default-access>
+            <access method="list*" roles="amq"/>
+            <access method="get*" roles="amq"/>
+            <access method="is*" roles="amq"/>
+            <access method="set*" roles="amq"/>
+            <access method="*" roles="amq"/>
+        </default-access>
+        <role-access>
+            <match domain="org.apache.activemq.artemis">
+                <access method="list*" roles="amq"/>
+                <access method="get*" roles="amq"/>
+                <access method="is*" roles="amq"/>
+                <access method="set*" roles="amq"/>
+                <access method="*" roles="amq"/>
+            </match>
+            <!--example of how to configure a specific object-->
+            <!--<match domain="org.apache.activemq.artemis" key="subcomponent=queues">
+               <access method="list*" roles="view,update,amq"/>
+               <access method="get*" roles="view,update,amq"/>
+               <access method="is*" roles="view,update,amq"/>
+               <access method="set*" roles="update,amq"/>
+               <access method="*" roles="amq"/>
+            </match>-->
+        </role-access>
+    </authorisation>
+</management-context>


### PR DESCRIPTION
AMQ Jon plugin supports AMQ 7's RBAC management feature. To be able to
have the right access to broker's management resource, Jon must
use a valid credential (username/password) to connect to the
broker. The broker uses JAAS login module to authenticate
against Jon's credentials and then authorizes any requests from
Jon plugin against the access-control policy defined in
management.xml.

The Jon plugin's default user is 'admin' and default password is 'activemq'.
You can configure the plugin to use a different user/password to connect
to the broker. The configuration file are located in the following path:

<artemis.instance>/etc/org.jboss.rh-messaging.amq.jon.cfg

This file takes the form of java properties file. It allows you to
specify the user name and password for the Jon plugin to connect to
the broker. You can also configure the jmx connector url in this file.

For example a configuration can have the following properties:

principal = guest
credentials = guest
connectorAddress = service:jmx:rmi:///jndi/rmi://localhost:11099/jmxrmi

where the value of 'principal' is the user name (i.e. guest); the
value of 'credentials' is password (i.e. guest); and the value
of 'connectorAddress' is the connector's url.